### PR TITLE
New CAN frame class to replace old classes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: python
 python:
-    - "3.3"
-    - "3.4"
     - "3.5"
     - "3.6"
 

--- a/cantoolz/can.py
+++ b/cantoolz/can.py
@@ -125,10 +125,11 @@ class CAN:
 
     @property
     def raw(self):
-        """"Representation of CAN data in bits.
+        """"Representation of CAN data in bytes.
 
-        :return: Byte array representing the CAN frame
-        :rtype: bytearray"""
+        :return: Bytes representing the CAN frame (id + length + data)
+        :rtype: bytes
+        """
         if self._data is None:
             return self.raw_id + self.raw_length
         return self.raw_id + self.raw_length + self.raw_data
@@ -162,7 +163,8 @@ class CAN:
         """"Representation of CAN data in bits.
 
         :return: Bits representation of CAN data
-        :rtype: bitstring.BitArray"""
+        :rtype: bitstring.BitArray
+        """
         fill = 8 - self._length
         bits_array = '0b' + '0' * fill * 8
         for byte in self._data:

--- a/cantoolz/can232.py
+++ b/cantoolz/can232.py
@@ -424,7 +424,7 @@ class CAN232:
     def transmit(self, data, mode=CAN_STANDARD):
         """Transmit a CAN message to the bus.
 
-        :param str data: CAN message to send.
+        :param bytes data: CAN message to send.
         :param int mode: Type of CAN frame (default: CAN_STANDARD)
             - CAN_STANDARD if standard CAN frame (i.e. 11bit)
             - CAN_EXTENDED if extended (e.g. 29bit CAN frame)

--- a/cantoolz/frag.py
+++ b/cantoolz/frag.py
@@ -39,24 +39,24 @@ class FragmentedCAN:
                 if p_x > 0:
                     self.messages.append(message)
 
-    def add_can_loop(self, can_msg):  # Check if there is INDEX byte in first byte
-        if can_msg.frame_length > 0:
-            if can_msg.frame_id not in self.temp_msg:
-                self.temp_msg[can_msg.frame_id] = collections.OrderedDict()
-                self.temp_msg[can_msg.frame_id]['idx'] = {}
-                self.temp_msg[can_msg.frame_id]['length'] = 0
-                self.temp_msg[can_msg.frame_id]['elements'] = 0
+    def add_can_loop(self, can):  # Check if there is INDEX byte in first byte
+        if can.length > 0:
+            if can.id not in self.temp_msg:
+                self.temp_msg[can.id] = collections.OrderedDict()
+                self.temp_msg[can.id]['idx'] = {}
+                self.temp_msg[can.id]['length'] = 0
+                self.temp_msg[can.id]['elements'] = 0
 
-            curr_elems = self.temp_msg[can_msg.frame_id]["elements"]
-            in_idx = can_msg.frame_data[0]
+            curr_elems = self.temp_msg[can.id]["elements"]
+            in_idx = can.data[0]
 
-            if curr_elems == 0 and not self.temp_msg[can_msg.frame_id]['elements'] < 0:
-                self.temp_msg[can_msg.frame_id]["elements"] += 1
-                self.temp_msg[can_msg.frame_id]["idx"][in_idx] = can_msg.frame_data[1:]
-                self.temp_msg[can_msg.frame_id]['length'] += len(can_msg.frame_data[1:])
-            elif in_idx in list(self.temp_msg[can_msg.frame_id]['idx'].keys()) and not self.temp_msg[can_msg.frame_id]['elements'] < 0:
-                self.temp_msg[can_msg.frame_id]["elements"] = -1
-            elif not self.temp_msg[can_msg.frame_id]['elements'] < 0:
-                self.temp_msg[can_msg.frame_id]["elements"] += 1
-                self.temp_msg[can_msg.frame_id]["idx"][in_idx] = can_msg.frame_data[1:]
-                self.temp_msg[can_msg.frame_id]['length'] += len(can_msg.frame_data[1:])
+            if curr_elems == 0 and not self.temp_msg[can.id]['elements'] < 0:
+                self.temp_msg[can.id]["elements"] += 1
+                self.temp_msg[can.id]["idx"][in_idx] = can.data[1:]
+                self.temp_msg[can.id]['length'] += len(can.data[1:])
+            elif in_idx in list(self.temp_msg[can.id]['idx'].keys()) and not self.temp_msg[can.id]['elements'] < 0:
+                self.temp_msg[can.id]["elements"] = -1
+            elif not self.temp_msg[can.id]['elements'] < 0:
+                self.temp_msg[can.id]["elements"] += 1
+                self.temp_msg[can.id]["idx"][in_idx] = can.data[1:]
+                self.temp_msg[can.id]['length'] += len(can.data[1:])

--- a/cantoolz/modules/firewall.py
+++ b/cantoolz/modules/firewall.py
@@ -25,38 +25,30 @@ class firewall(CANModule):
     version = 1.0
 
     # Effect (could be fuzz operation, sniff, filter or whatever)
-    def do_effect(self, can_msg, args):
-        if can_msg.CANData:
-            if 'black_list' in args and can_msg.CANFrame.frame_id in args.get('black_list', []):
-                can_msg.CANData = False
-                self.dprint(2, "Message " + str(can_msg.CANFrame.frame_id) + " has been blocked(BL) (BUS = " + str(
-                    can_msg.bus) + ")")
-            elif 'white_list' in args and can_msg.CANFrame.frame_id not in args.get('white_list', []):
-                can_msg.CANData = False
-                self.dprint(2, "Message " + str(can_msg.CANFrame.frame_id) + " has been blocked(WL) (BUS = " + str(
-                    can_msg.bus) + ")")
-            if 'white_body' in args and can_msg.CANFrame.frame_data not in args.get('white_body', []):
-                can_msg.CANData = False
-                self.dprint(2, "Message " + str(can_msg.CANFrame.frame_id) + " has been blocked(WB) (BUS = " + str(
-                    can_msg.bus) + ")")
-            elif 'black_body' in args and can_msg.CANFrame.frame_data in args.get('black_body', []):
-                can_msg.CANData = False
-                self.dprint(2, "Message " + str(can_msg.CANFrame.frame_id) + " has been blocked(BB) (BUS = " + str(
-                    can_msg.bus) + ")")
-            if 'hex_white_body' in args and self.get_hex(can_msg.CANFrame.frame_raw_data) not in args.get('hex_white_body', []):
-                can_msg.CANData = False
-                self.dprint(2, "Message " + str(can_msg.CANFrame.frame_id) + " has been blocked(WB) (BUS = " + str(
-                    can_msg.bus) + ")")
-            elif 'hex_black_body' in args and self.get_hex(can_msg.CANFrame.frame_raw_data) in args.get('hex_black_body', []):
-                can_msg.CANData = False
-                self.dprint(2, "Message " + str(can_msg.CANFrame.frame_id) + " has been blocked(BB) (BUS = " + str(
-                    can_msg.bus) + ")")
-            if 'black_bus' in args and can_msg.bus.strip() in args.get('black_body', []):
-                can_msg.CANData = False
-                self.dprint(2, "Message " + str(can_msg.CANFrame.frame_id) + " has been blocked(BBus) (BUS = " + str(
-                    can_msg.bus) + ")")
-            elif 'white_bus' in args and can_msg.bus.strip() not in args.get('white_bus', []):
-                can_msg.CANData = False
-                self.dprint(2, "Message " + str(can_msg.CANFrame.frame_id) + " has been blocked(WBus) (BUS = " + str(
-                    can_msg.bus) + ")")
-        return can_msg
+    def do_effect(self, can, args):
+        if can.data is not None:
+            if 'black_list' in args and can.id in args.get('black_list', []):
+                can.data = None
+                self.dprint(2, "Message " + str(can.id) + " has been blocked(BL) (BUS = " + str(can.bus) + ")")
+            elif 'white_list' in args and can.id not in args.get('white_list', []):
+                can.data = None
+                self.dprint(2, "Message " + str(can.id) + " has been blocked(WL) (BUS = " + str(can.bus) + ")")
+            if 'white_body' in args and can.data not in args.get('white_body', []):
+                can.data = None
+                self.dprint(2, "Message " + str(can.id) + " has been blocked(WB) (BUS = " + str(can.bus) + ")")
+            elif 'black_body' in args and can.data in args.get('black_body', []):
+                can.data = None
+                self.dprint(2, "Message " + str(can.id) + " has been blocked(BB) (BUS = " + str(can.bus) + ")")
+            if 'hex_white_body' in args and self.get_hex(can.raw_data) not in args.get('hex_white_body', []):
+                can.data = None
+                self.dprint(2, "Message " + str(can.id) + " has been blocked(WB) (BUS = " + str(can.bus) + ")")
+            elif 'hex_black_body' in args and self.get_hex(can.raw_data) in args.get('hex_black_body', []):
+                can.data = None
+                self.dprint(2, "Message " + str(can.id) + " has been blocked(BB) (BUS = " + str(can.bus) + ")")
+            if 'black_bus' in args and can.bus.strip() in args.get('black_body', []):
+                can.data = None
+                self.dprint(2, "Message " + str(can.id) + " has been blocked(BBus) (BUS = " + str(can.bus) + ")")
+            elif 'white_bus' in args and can.bus.strip() not in args.get('white_bus', []):
+                can.data = None
+                self.dprint(2, "Message " + str(can.id) + " has been blocked(WBus) (BUS = " + str(can.bus) + ")")
+        return can

--- a/cantoolz/modules/io/hw_CANBusTriple.py
+++ b/cantoolz/modules/io/hw_CANBusTriple.py
@@ -4,7 +4,7 @@ import struct
 import serial
 import serial.tools.list_ports
 
-from cantoolz.can import CANMessage
+from cantoolz.can import CAN
 from cantoolz.module import CANModule, Command
 
 
@@ -228,77 +228,71 @@ class hw_CANBusTriple(CANModule):
         self._serialPort.write(bytes.fromhex(data))
         return ""
 
-    def do_effect(self, can_msg, args):  # read full packet from serial port
+    def do_effect(self, can, args):  # read full packet from serial port
         if args.get('action') == 'read':
-            can_msg = self.do_read(can_msg, args)
+            can = self.do_read(can, args)
         elif args.get('action') == 'write':
-            self.do_write(can_msg, args)
+            can = self.do_write(can, args)
         else:
             self.dprint(1, 'Command ' + args['action'] + ' not implemented 8(')
             self.set_error_text('Command ' + args['action'] + ' not implemented 8(')
-        return can_msg
+        return can
 
-    def do_read(self, can_msg, args):
+    def do_read(self, can, args):
         data = b""
         counter = 0
         r_bus = int(args.get("bus", 0))
 
         if 0 < r_bus < 4:
             if len(self._queue[r_bus - 1]) > 0:
-                if not can_msg.CANData and not can_msg.debugData:
-                    can_msg.CANFrame = self._queue[r_bus - 1].pop(0)
-                    can_msg.bus = r_bus
-                    can_msg.CANData = True
-                    print("BUS " + str(r_bus))
-                    print("POP: " + str(can_msg.CANFrame))
+                if can.data is None and not can.debug:
+                    can = self._queue[r_bus - 1].pop(0)
+                    can.bus = r_bus
+                    self.dprint(3, 'BUS: {}'.format(str(r_bus)))
+                    self.dprint(3, 'POP: {}'.format(str(can)))
             elif self._serialPort.inWaiting() > 0:
-                while not can_msg.CANData and not can_msg.debugData:
+                while can.data is None and not can.debug:
                     byte = self._serialPort.read(1)
                     if byte == b"":
                         break
-
                     data += byte
                     counter += 1
 
                     if data[-2:] == b"\r\n":  # End
                         if data[0:1] == b'\x03' and counter == 16:  # Packet received
-
                             tmp_data = data[2:-3]
 
-                            _id = struct.unpack("!H", tmp_data[0:2])[0]  # TODO: ADD SUPPORT EXTENDED and RTR
-                            _data = tmp_data[2:-1]
-                            _length = tmp_data[-1]
+                            id = struct.unpack("!H", tmp_data[0:2])[0]  # TODO: ADD SUPPORT EXTENDED and RTR
+                            data = tmp_data[2:-1]
+                            length = tmp_data[-1]
                             bus = (struct.unpack("B", data[1:2])[0])
                             if r_bus == bus:
-                                can_msg.CANFrame = CANMessage(_id, _length, _data, False, CANMessage.DataFrame)
-                                can_msg.bus = str(self._bus) + '_' + str(bus)
-                                can_msg.CANData = True
-                                print("BUS " + str(r_bus))
-                                print("MESS:" + str(_id) + " " + str(_length) + " " + self.get_hex(_data))
-                                print(self.get_hex(tmp_data))
+                                can.init(id=id, length=length, data=data, bus='{}_{}'.format(self._bus, bus))
+                                self.dprint(3, 'BUS: {}'.format(r_bus))
+                                self.dprint(3, 'MESS: {}'.format(can))
                             else:
-                                self._queue[bus - 1].append(CANMessage(_id, _length, _data, False, CANMessage.DataFrame))
-                                print("BUS " + str(r_bus))
-                                print("QUEU:" + str(_id) + " " + str(_length) + " " + self.get_hex(_data))
-                                print(self.get_hex(tmp_data))
+                                new_can = CAN(id=id, length=length, data=data, bus=bus)
+                                self._queue[bus - 1].append(new_can)
+                                self.dprint(3, 'BUS: {}'.format(r_bus))
+                                self.dprint(3, 'QUEUE: {}'.format(new_can))
                         elif data[0:1] == b'{' and data[-3:-2] == b'}':  # Debug info
-                            can_msg.debugData = True
-                            can_msg.debugText = {'text': data.decode("ISO-8859-1")}
+                            can.debug = {'text': data.decode("ISO-8859-1")}
                         else:
                             break
+                        self.dprint(2, "READ: {}".format(str(can)))
+        return can
 
-                        self.dprint(2, "READ: " + self.get_hex(data))
-        return can_msg
-
-    def do_write(self, can_msg, params):
-        if can_msg.CANData and not can_msg.CANFrame.frame_ext and can_msg.CANFrame.frame_type == CANMessage.DataFrame:  # Only 11 bit support now..., only DataFrame
-            bs = int(params.get('bus', '0'))
-            if 0 < bs < 4:
-                write_buf = b"\x02" + struct.pack("B", bs) + can_msg.CANFrame.frame_raw_id + \
-                    can_msg.CANFrame.frame_raw_data + \
-                    (b"\x00" * (8 - can_msg.CANFrame.frame_length)) + \
-                    can_msg.CANFrame.frame_raw_length
-                print("NUL:" + str(8 - can_msg.CANFrame.frame_length))
-                print(str(can_msg.CANFrame.frame_raw_data))
-                self._serialPort.write(write_buf)
-                self.dprint(2, "WRITE: " + self.get_hex(write_buf))
+    def do_write(self, can, params):
+        # Only 11 bit data frame are supported for now.
+        # TODO: Add support for other frame types/modes (remote, extended, etc.)
+        if can.data is not None and can.mode != CAN.EXTENDED and can.type == CAN.DATA:
+            bus = int(params.get('bus', '0'))
+            if 0 < bus < 4:
+                buf = b'\x02' + struct.pack('B', bus)
+                buf += can.raw_id + can.raw_data
+                buf += b'\x00' * (8 - can.length)
+                buf += can.raw_length
+                self._serialPort.write(buf)
+                self.dprint(2, "WRITE: {}".format(can))
+            else:
+                self.dprint(0, 'WRITE: Invalid bus id {}'.format(bus))

--- a/cantoolz/modules/io/hw_CANBusTriple.py
+++ b/cantoolz/modules/io/hw_CANBusTriple.py
@@ -296,3 +296,4 @@ class hw_CANBusTriple(CANModule):
                 self.dprint(2, "WRITE: {}".format(can))
             else:
                 self.dprint(0, 'WRITE: Invalid bus id {}'.format(bus))
+        return can

--- a/cantoolz/modules/io/hw_CANSocket.py
+++ b/cantoolz/modules/io/hw_CANSocket.py
@@ -110,3 +110,4 @@ class hw_CANSocket(CANModule):
             buf += b'0' * (8 - can.length)
             self.socket.send(buf)
             self.dprint(2, "WRITE: " + self.get_hex(buf))
+        return can

--- a/cantoolz/modules/ping.py
+++ b/cantoolz/modules/ping.py
@@ -1,6 +1,6 @@
 import time
 
-from cantoolz.can import CANMessage
+from cantoolz.can import CAN
 from cantoolz.uds import UDSMessage
 from cantoolz.isotp import ISOTPMessage
 from cantoolz.module import CANModule
@@ -105,7 +105,7 @@ class ping(CANModule):
                 iso_list.reverse()
                 self.queue_messages.extend(iso_list)
             elif iso_mode == 0:
-                self.queue_messages.append(CANMessage.init_data(i, len(data), data[:8]))
+                self.queue_messages.append(CAN(id=i, length=len(data), data=data[:8]))
             elif iso_mode == 2:
                 for service in args.get('services', []):
                     uds_m = UDSMessage(shift, padding)
@@ -123,23 +123,22 @@ class ping(CANModule):
         self._full = len(self.queue_messages)
         self._last = 0
 
-    def do_effect(self, can_msg, args):
+    def do_effect(self, can, args):
         d_time = float(args.get('delay', 0))
-        if not can_msg.CANData:
+        if can.data is None:
             if d_time > 0:
                 if time.clock() - self.last >= d_time:
                     self.last = time.clock()
-                    can_msg.CANFrame = self.do_ping(args)
-
+                    # Either get the last ping CAN message or pass along the current CAN message if no ping messages.
+                    can = self.do_ping(args) or can
                 else:
-                    can_msg.CANFrame = None
+                    can.data = None
             else:
-                can_msg.CANFrame = self.do_ping(args)
+                # Either get the last ping CAN message or pass along the current CAN message if no ping messages.
+                can = self.do_ping(args) or can
 
-            if can_msg.CANFrame and not can_msg.CANData:
-                can_msg.CANData = True
-                can_msg.bus = self._bus
+            if can and can.data is None:
+                can.bus = self._bus
                 self._last += 1
                 self._status = self._last / (self._full / 100.0)
-
-        return can_msg
+        return can

--- a/cantoolz/modules/pipe_switch.py
+++ b/cantoolz/modules/pipe_switch.py
@@ -31,11 +31,11 @@ class pipe_switch(CANModule):
         self.can_buffer = None
 
     # Effect (could be fuzz operation, sniff, filter or whatever)
-    def do_effect(self, can_msg, args):
-        if args.get('action') == 'read' and can_msg.CANData:
-            self.can_buffer = copy.deepcopy(can_msg)
+    def do_effect(self, can, args):
+        if args.get('action') == 'read' and can.data is not None:
+            self.can_buffer = copy.deepcopy(can)
         elif args.get('action') == 'write' and self.can_buffer:
-            can_msg = copy.deepcopy(self.can_buffer)
+            can = copy.deepcopy(self.can_buffer)
             self.can_buffer = None
 
-        return can_msg
+        return can

--- a/cantoolz/modules/replay.py
+++ b/cantoolz/modules/replay.py
@@ -125,20 +125,19 @@ class replay(CANModule):
         return "Loaded packets: " + ret
 
     # Effect (could be fuzz operation, sniff, filter or whatever)
-    def do_effect(self, can_msg, args):
-        if self._sniff and can_msg.CANData:
-            self.CANList.append(can_msg)
-        elif self._replay and not can_msg.CANData:
+    def do_effect(self, can, args):
+        if self._sniff and can.data is not None:
+            self.CANList.append(can)
+        elif self._replay and can.data is None:
             d_time = float(args.get('delay', 0))
             ignore = bool(args.get('ignore_time', False))
             try:
-                next_msg = self.CANList.next(d_time, ignore)
-                if next_msg and next_msg.CANData:
-                    can_msg.CANFrame = next_msg.CANFrame
+                next_can = self.CANList.next(d_time, ignore)
+                if next_can and next_can.data is not None:
+                    can = next_can
                     self._num1 += 1
-                    can_msg.CANData = True
                     self._last += 1
-                can_msg.bus = self._bus
+                can.bus = self._bus
                 self._status = self._last / (self._full / 100.0)
             except Exception:
                 self._replay = False
@@ -148,4 +147,4 @@ class replay(CANModule):
                 self._replay = False
                 self.commands['g'].is_enabled = True
                 self.CANList.reset()
-        return can_msg
+        return can

--- a/cantoolz/stream/subnet.py
+++ b/cantoolz/stream/subnet.py
@@ -9,7 +9,7 @@ class Subnet(Processor):
         self._device_builder = device_builder
 
     def process(self, message) -> Iterable:
-        stream = str(message) + ":" + str(len(message))
+        stream = hex(message.id) + ":" + str(len(message))
         if stream not in self._devices:
             self._devices[stream] = self._device_builder(stream)
 

--- a/tests/configurations/conf_ping.py
+++ b/tests/configurations/conf_ping.py
@@ -9,4 +9,5 @@ actions = [
     {'ping': {'pipe': 2}},
     {'ping~1': {'pipe': 1}},
     {'hw_fakeIO': {'action': 'write', 'pipe': 2}},
-    {'analyze': {'pipe': 2}}, {'analyze': {'pipe': 1}}]
+    {'analyze': {'pipe': 2}},
+    {'analyze': {'pipe': 1}}]

--- a/tests/modules/test_firewall.py
+++ b/tests/modules/test_firewall.py
@@ -15,7 +15,7 @@ class TestFirewall(TestCANToolz):
         time.sleep(1)
         mod = self.CANEngine.actions[index][1].CANList
         self.assertFalse(len(mod) == 0, "We should find message in PIPE")
-        self.assertTrue(mod[-1].frame_id == 4, "We should be able to find ID 4")
+        self.assertTrue(mod[-1].id == 4, "We should be able to find ID 4")
 
         self.CANEngine.actions[index][1].CANList = []
 
@@ -31,7 +31,7 @@ class TestFirewall(TestCANToolz):
         time.sleep(1)
         mod = self.CANEngine.actions[index][1].CANList
         self.assertFalse(len(mod) == 0, "We should find message in PIPE")
-        self.assertTrue(mod[-1].frame_id == 4, "We should be able to find ID 4")
+        self.assertTrue(mod[-1].id == 4, "We should be able to find ID 4")
         self.CANEngine.actions[index][1].CANList = []
 
         self.CANEngine.call_module(0, 't 4:6:010203060505')  # blocked
@@ -50,7 +50,7 @@ class TestFirewall(TestCANToolz):
         time.sleep(1)
         mod = self.CANEngine.actions[index][1].CANList
         self.assertFalse(len(mod) == 0, "We should find message in PIPE")
-        self.assertTrue(mod[-1].frame_id == 4, "We should be able to find ID 4")
+        self.assertTrue(mod[-1].id == 4, "We should be able to find ID 4")
         self.CANEngine.actions[index][1].CANList = []
 
         self.CANEngine.call_module(0, 't 4:5:0102030605')  # blocked
@@ -65,7 +65,7 @@ class TestFirewall(TestCANToolz):
         time.sleep(1)
         mod = self.CANEngine.actions[index][1].CANList
         self.assertFalse(len(mod) == 0, "We should find message in PIPE")
-        self.assertTrue(mod[-1].frame_id == 4, "We should be able to find ID 4")
+        self.assertTrue(mod[-1].id == 4, "We should be able to find ID 4")
         self.CANEngine.actions[index][1].CANList = []
 
         self.CANEngine.call_module(0, 't 4:6:010203060505')  # blocked
@@ -84,7 +84,7 @@ class TestFirewall(TestCANToolz):
         time.sleep(1)
         mod = self.CANEngine.actions[index][1].CANList
         self.assertFalse(len(mod) == 0, "We should find message in PIPE")
-        self.assertTrue(mod[-1].frame_id == 4, "We should be able to find ID 4")
+        self.assertTrue(mod[-1].id == 4, "We should be able to find ID 4")
         self.CANEngine.actions[index][1].CANList = []
 
         self.CANEngine.call_module(0, 't 1:4:11223344')
@@ -96,7 +96,7 @@ class TestFirewall(TestCANToolz):
         self.CANEngine.call_module(0, 't 7:4:11223344')  # pass
         time.sleep(1)
         mod = self.CANEngine.actions[index][1].CANList
-        self.assertTrue(mod[-1].frame_id == 7, "We should be able to find ID 7")
+        self.assertTrue(mod[-1].id == 7, "We should be able to find ID 7")
         self.CANEngine.actions[index][1].CANList = []
 
         self.CANEngine.call_module(0, 't 1:4:11223344')
@@ -113,5 +113,5 @@ class TestFirewall(TestCANToolz):
         self.CANEngine.call_module(0, 't 4:4:11223344')  # pass
         time.sleep(1)
         mod = self.CANEngine.actions[index][1].CANList
-        self.assertTrue(mod[-1].frame_id == 4, "We should be able to find ID 4")
+        self.assertTrue(mod[-1].id == 4, "We should be able to find ID 4")
         self.CANEngine.actions[index][1].CANList = []

--- a/tests/test_can.py
+++ b/tests/test_can.py
@@ -1,0 +1,79 @@
+import unittest
+import struct
+import bitstring
+
+from cantoolz.can import CAN
+
+
+class TestCan(unittest.TestCase):
+
+    def test_init(self):
+        # Init CAN without any parameters
+        can = CAN()
+        self.assertTrue(can.id == 0 and can.length is None and can.data is None and can.mode == CAN.STANDARD and can.type == CAN.DATA and can.bus == 'Default' and can.debug == None)
+        # Standard
+        can = CAN(id=1, length=1, data=[1])
+        self.assertTrue(can.id == 1 and can.length == 1 and can.data == [1] and can.mode == CAN.STANDARD and can.type == CAN.DATA and can.bus == 'Default' and can.debug == None)
+        # Extended
+        can = CAN(id=1, length=1, data=[1], mode=CAN.EXTENDED)
+        self.assertTrue(can.id == 1 and can.length == 1 and can.data == [1] and can.mode == CAN.EXTENDED)
+        can = CAN(id=0x800, length=1, data=[1])
+        self.assertTrue(can.id == 0x800 and can.length == 1 and can.data == [1] and can.mode == CAN.EXTENDED and can.type == CAN.DATA and can.bus == 'Default' and can.debug == None)
+
+    def test_attributes(self):
+        can = CAN()
+        can.id = 1
+        self.assertTrue(can.id == 1 and can.mode == CAN.STANDARD)
+        can = CAN()
+        can.id = 1
+        can.mode = CAN.EXTENDED
+        self.assertTrue(can.id == 1 and can.mode == CAN.EXTENDED)
+        can = CAN()
+        can.id = 0x800
+        self.assertTrue(can.id == 0x800 and can.mode == CAN.EXTENDED)
+        can = CAN()
+        can.id = 0x10000
+        can.mode = CAN.STANDARD
+        with self.assertRaises(struct.error):
+            _ = can.raw_id
+
+    def test_remote(self):
+        can = CAN(id=1, length=1, data=[1], type=CAN.REMOTE)
+        self.assertTrue(can.type == CAN.REMOTE and can.data == [] and can.length == 1)
+        can = CAN(id=1, length=1, data=[1])
+        can.type = CAN.REMOTE
+        self.assertTrue(can.type == CAN.REMOTE and can.data == [] and can.length == 1)
+
+    def test_raw_attributes(self):
+        can = CAN(data=[1])
+        self.assertTrue(can.data == [1] and can.raw_data == b'\x01')
+        can = CAN(id=2, mode=CAN.STANDARD)
+        self.assertTrue(can.id == 2 and can.raw_id == b'\x00\x02')
+        can = CAN(id=2, mode=CAN.EXTENDED)
+        self.assertTrue(can.id == 2 and can.raw_id == b'\x00\x00\x00\x02')
+        can = CAN(length=3)
+        self.assertTrue(can.length == 3 and can.raw_length == b'\x03')
+        can = CAN(id=1, length=1, data=[1])
+        self.assertTrue(can.raw == b'\x00\x01\x01\x01')
+        can = CAN(id=1, length=1, type=CAN.REMOTE)
+        self.assertTrue(can.raw == b'\x00\x01\x01')
+
+    def test_transformation(self):
+        can = CAN(id=1, length=2, data=[3, 4])
+        self.assertTrue(int(can) == 1 and bytes(can) == b'\x03\x04' and str(can) == '0x1:2:0304' and repr(can) == '<CAN(id=1, length=2, data=[3, 4])>')
+
+    def test_bits(self):
+        can = CAN(id=1, length=3, data=[3, 1, 2])
+        self.assertTrue(can.bits == bitstring.BitArray('0b0000000000000000000000000000000000000000000000110000000100000010', length=64))
+
+    def test_truncated_data(self):
+        can = CAN(id=1, length=0, data=[1, 2, 3])
+        self.assertTrue(can.data == [])
+        can = CAN(id=1, length=1, data=[1, 2, 3])
+        self.assertTrue(can.data == [1])
+        can = CAN(id=1, length=2, data=[1, 2, 3])
+        self.assertTrue(can.data == [1, 2])
+        can = CAN(id=1, length=3, data=[1, 2, 3])
+        self.assertTrue(can.data == [1, 2, 3])
+        can = CAN(id=1, length=4, data=[1, 2, 3])
+        self.assertTrue(can.data == [1, 2, 3])


### PR DESCRIPTION
Practical class for handling CAN frame with attributes:
- id: CAN frame ID
- length: CAN frame length
- data: CAN frame data
- mode: CAN frame standard or extended
- type: CAN data, remote, error or overload frame
- bus: CAN bus
- debug: debug dictionary

And advanced attributes:
- raw_id: CAN frame ID (bytes)
- raw_length: CAN frame length (bytes)
- raw_data: CAN frame data (bytes)
- raw: CAN frame ID+length+data (bytes)
- bits: CAN frame data in bits (BitArray)

Examples:
```python
# Before
_bodyList[can_msg.CANFrame.frame_id][(can_msg.CANFrame.frame_length, can_msg.CANFrame.frame_raw_data, can_msg.bus, can_msg.CANFrame.frame_ext)] = 1
# After
_bodyList[can.id][(can.length, can.raw_data, can.bus, can.type == CAN.EXTENDED)] = 1

# Before
if can_msg.CANData:
    if can_msg.CANFrame.frame_id not in _bodyList:
# After
if can.data is not None:
    if can.id not in _bodyList:

# Before
if 1 < can_msg.CANFrame.frame_length:
# After
if 1 < can.length:

# Before
self._C232.transmit(can.CANFrame.to_hex(), mode=can232.CAN_EXTENDED)
# After
self._C232.transmit(can.raw, mode=can232.CAN_EXTENDED)
```

This PR does break compatibility with Python 3.3 and 3.4 because it uses `bytes().hex()` added in Python 3.5 (https://docs.python.org/3/library/stdtypes.html#bytes.hex).