### PR TITLE
Import Iterable from collections.abc

### DIFF
--- a/cantoolz/stream/forced_sampler.py
+++ b/cantoolz/stream/forced_sampler.py
@@ -1,4 +1,4 @@
-from collections import Iterable
+from collections.abc import Iterable
 from itertools import combinations_with_replacement as combinations
 
 from cantoolz.stream.processor import Processor

--- a/cantoolz/stream/integrator.py
+++ b/cantoolz/stream/integrator.py
@@ -1,4 +1,5 @@
-from collections import Iterable, deque
+from collections import deque
+from collections.abc import Iterable
 
 from cantoolz.stream.processor import Processor
 

--- a/cantoolz/stream/normalizer.py
+++ b/cantoolz/stream/normalizer.py
@@ -1,7 +1,8 @@
 import math
 import numpy
 
-from collections import Iterable, deque
+from collections import deque
+from collections.abc import Iterable
 
 from cantoolz.stream.processor import Processor
 

--- a/cantoolz/stream/processor.py
+++ b/cantoolz/stream/processor.py
@@ -1,4 +1,4 @@
-from collections import Iterable
+from collections.abc import Iterable
 
 
 class Processor:

--- a/cantoolz/stream/sampler.py
+++ b/cantoolz/stream/sampler.py
@@ -1,4 +1,5 @@
-from collections import Counter, Iterable
+from collections import Counter
+from collections.abc import Iterable
 
 from cantoolz.stream.processor import Processor
 

--- a/cantoolz/stream/selector.py
+++ b/cantoolz/stream/selector.py
@@ -1,4 +1,4 @@
-from collections import Iterable
+from collections.abc import Iterable
 
 from cantoolz.stream.processor import Processor
 

--- a/cantoolz/stream/separator.py
+++ b/cantoolz/stream/separator.py
@@ -1,4 +1,5 @@
-from collections import Counter, deque, Iterable
+from collections import Counter, deque
+from collections.abc import Iterable
 
 from cantoolz.stream.processor import Processor
 from cantoolz.utils import bits

--- a/cantoolz/stream/subnet.py
+++ b/cantoolz/stream/subnet.py
@@ -1,4 +1,4 @@
-from collections import Iterable
+from collections.abc import Iterable
 
 from cantoolz.stream.processor import Processor
 


### PR DESCRIPTION
This allows building it on Python 3.10, where it was moved out of
collections.